### PR TITLE
Consume grid ftp

### DIFF
--- a/nodetypes/radon.nodes.aws/AwsApiGateway/NodeType.tosca
+++ b/nodetypes/radon.nodes.aws/AwsApiGateway/NodeType.tosca
@@ -10,6 +10,8 @@ node_types:
     attributes:
       arn:
         type: string
+      endpoint_url: 
+        type: string
     properties:
       api_title:
         type: string

--- a/nodetypes/radon.nodes.aws/AwsApiGateway/README.md
+++ b/nodetypes/radon.nodes.aws/AwsApiGateway/README.md
@@ -14,6 +14,8 @@ A node type that represents an AWS Lambda Function.
 | Name | Type | Default Value | Description |
 |:---- |:---- |:------------- |:----------- |
 | `arn` | `string` |   | Amazon's resource name for this entity |
+| `endpoint_url` | `string` |   | Base URL for endpoints provided by this API |
+
 
 ### Properties
 

--- a/nodetypes/radon.nodes.aws/AwsApiGateway/files/configure/configure.yml
+++ b/nodetypes/radon.nodes.aws/AwsApiGateway/files/configure/configure.yml
@@ -1,9 +1,16 @@
 ---
 - hosts: all
+  vars:
+    api_gw_stage: "production"
   tasks:
     - name: Deploy API gateway
       aws_api_gateway:
         state: present
         swagger_file: "/tmp/swagger.json"
-        stage: production
+        stage: "{{ api_gw_stage }}"
         region: "{{ aws_region }}"
+      register: api_gw
+    - name: Set attributes
+      set_stats:
+        data:
+          endpoint_url: "https://{{ api_gw.api_id }}.execute-api.{{ aws_region }}.amazonaws.com/{{ api_gw_stage }}"

--- a/nodetypes/radon.nodes.datapipeline.destination/PublishGridFtp/NodeType.tosca
+++ b/nodetypes/radon.nodes.datapipeline.destination/PublishGridFtp/NodeType.tosca
@@ -101,5 +101,5 @@ node_types:
         file: create.yml
       configure:
         type: radon.artifacts.Ansible
-        description: implementation of the configure operation
+        description: implementation of configure operation
         file: configure.yml

--- a/nodetypes/radon.nodes.datapipeline.destination/PublishGridFtp/NodeType.tosca
+++ b/nodetypes/radon.nodes.datapipeline.destination/PublishGridFtp/NodeType.tosca
@@ -1,0 +1,80 @@
+tosca_definitions_version: tosca_simple_yaml_1_3
+
+node_types:
+  radon.nodes.datapipeline.destination.PublishGridFtp:
+    derived_from: radon.nodes.datapipeline.destination.PublishRemote
+    metadata:
+      targetNamespace: "radon.nodes.datapipeline.destination"
+      abstract: "false"
+      final: "false"
+    attributes:
+      template_name:
+        description: name of the template
+        type: string
+        default: "GridFTPpublish"
+    interfaces:
+      Standard:
+        type: tosca.interfaces.node.lifecycle.Standard
+        operations:
+          create:
+            description: The standard create operation
+            inputs:
+              template_name:
+                type: string
+                required: true
+                default: { get_attribute: [ SELF, template_name ] }
+              template_file:
+                type: string
+                required: true
+                default: "GridFTPpublish.xml"
+            implementation:
+              primary: create
+              dependencies: [ templateFile_localConn ]
+              timeout: 0
+          configure:
+            description: The standard configure operation
+            inputs:
+              gridftp_port:
+                type: string
+                required: true
+                default: { get_property: [ SELF, gridftp_port ] }
+              intermediate_folder:
+                type: string
+                required: true
+                default: { get_property: [ SELF, intermediate_folder ] }
+              pipeline_id:
+                type: string
+                required: true
+                default: { get_attribute: [ SELF, id ] }
+              gridftp_user:
+                type: string
+                required: true
+                default: { get_property: [ SELF, gridftp_user ] }
+              gridftp_host:
+                type: string
+                required: true
+                default: { get_property: [ SELF, gridftp_host ] }
+              gridftp_directory:
+                type: string
+                required: true
+                default: { get_property: [ SELF, gridftp_directory ] }
+              gridftp_cert_path:
+                type: string
+                required: true
+                default: { get_property: [ SELF, gridftp_cert_path ] }
+            implementation:
+              primary: configure
+              timeout: 0
+    artifacts:
+      templateFile_localConn:
+        type: radon.artifacts.Ansible
+        description: XML template file
+        file: GridFTPpublish.xml
+      create:
+        type: radon.artifacts.Ansible
+        description: create operation implementation in Ansible
+        file: create.yml
+      configure:
+        type: radon.artifacts.Ansible
+        description: Implementation of the configure life cycle operation
+        file: configure.yml

--- a/nodetypes/radon.nodes.datapipeline.destination/PublishGridFtp/NodeType.tosca
+++ b/nodetypes/radon.nodes.datapipeline.destination/PublishGridFtp/NodeType.tosca
@@ -12,6 +12,31 @@ node_types:
         description: name of the template
         type: string
         default: "GridFTPpublish"
+    properties:
+      gridftp_port:
+        type: string
+        description: port of the gridftp server
+        default: 2811
+      intermediate_folder:
+        type: string
+        description: Where the data pipeline server keeps intermediate data. MUST be unique folder.
+        default: "/tmp/nifi_gridftp_subscribe/"
+      gridftp_user:
+        type: string
+        description: user of the gridftp server
+        default: "pelle"
+      gridftp_host:
+        type: string
+        description: hostname of the gridftp server
+        default: "gridftpserver.com"
+      gridftp_cert_path:
+        type: string
+        description: where the orchestrator copies certificates from, to enable connection into GridFTP server using the specified user. Folder has to be acc$
+        default: "/tmp/gridftp_certs/"
+      gridftp_directory:
+        type: string
+        description: directory where to write data inside the GridFTP server
+        default: "~/gridftp_input/"
     interfaces:
       Standard:
         type: tosca.interfaces.node.lifecycle.Standard
@@ -76,5 +101,5 @@ node_types:
         file: create.yml
       configure:
         type: radon.artifacts.Ansible
-        description: Implementation of the configure life cycle operation
+        description: implementation of the configure operation
         file: configure.yml

--- a/nodetypes/radon.nodes.datapipeline.destination/PublishGridFtp/files/configure/configure.yml
+++ b/nodetypes/radon.nodes.datapipeline.destination/PublishGridFtp/files/configure/configure.yml
@@ -20,19 +20,17 @@
   vars: 
     get_id1: "processors[?component.name=='ExecuteProcess'].id" 
     get_id2: "processors[?component.name=='PutFile'].id"  
-    dest_cred_file_path: "~/.globus/"
+    dest_cred_file_path: "/root/"
     proccess_arguments: "-sync -r {{intermediate_folder}} gsiftp://{{gridftp_user}}@{{gridftp_host}}:{{gridftp_port}}/{{gridftp_directory}}"
 
   tasks:
-    - name: create directory for cred file
-      file:
-        path: "{{dest_cred_file_path}}"
-        state: directory
 
-    - name: Upload the credentials file to the current directory. 
+    - name: Upload the certificate files  
       copy:
         src: "{{gridftp_cert_path}}"
         dest: "{{dest_cred_file_path}}"
+        mode: 0600
+      become: yes
       when: gridftp_cert_path != "none" or gridftp_cert_path != "None"
 
 

--- a/nodetypes/radon.nodes.datapipeline.destination/PublishGridFtp/files/configure/configure.yml
+++ b/nodetypes/radon.nodes.datapipeline.destination/PublishGridFtp/files/configure/configure.yml
@@ -41,13 +41,13 @@
         url: "http://localhost:8080/nifi-api/process-groups/{{pipeline_id}}/processors"
         method: Get
       register: nifi_resources
-      when: cred_file_path != "none" or cred_file_path != "None"
+
 
 
 
     - name: Configure the ExecuteProcess process group
       vars:
-        first_prcsr_id: "{{ nifi_resources.json  | to_json | from_json | json_query(get_id1) }}"
+        first_prcsr_id: "{{ nifi_resources.json  | to_json | from_json | json_query(get_id1) | first }}"
       uri:
         url: "http://localhost:8080/nifi-api/processors/{{first_prcsr_id}}"
         method: PUT
@@ -62,9 +62,9 @@
         status_code: 200
         body_format: json
 
-    - name: Configure the ListFile processor within the process group
+    - name: Configure the PutFile processor within the process group
       vars:       
-        second_prcsr_id: "{{ nifi_resources.json  | to_json | from_json | json_query(get_id2) }}"
+        second_prcsr_id: "{{ nifi_resources.json  | to_json | from_json | json_query(get_id2) | first }}"
       uri:
         url: "http://localhost:8080/nifi-api/processors/{{second_prcsr_id}}"
         method: PUT
@@ -74,7 +74,7 @@
             "id": "{{second_prcsr_id}}"
             "config": 
               "properties": {  
-                 "properties": { "Directory": "{{intermediate_folder}}"}
+                 "Directory": "{{intermediate_folder}}",
               }                       
         status_code: 200
         body_format: json

--- a/nodetypes/radon.nodes.datapipeline.destination/PublishGridFtp/files/configure/configure.yml
+++ b/nodetypes/radon.nodes.datapipeline.destination/PublishGridFtp/files/configure/configure.yml
@@ -1,0 +1,87 @@
+  ##########################################################################
+  # Copyright (c) 2019 Contributors to the RADON project
+  #
+  # Licensed under the Apache License, Version 2.0 (the "License");
+  # you may not use this file except in compliance with the License.
+  # You may obtain a copy of the License at
+  #
+  #     http://www.apache.org/licenses/LICENSE-2.0
+  #
+  # Unless required by applicable law or agreed to in writing, software
+  # distributed under the License is distributed on an "AS IS" BASIS,
+  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  # See the License for the specific language governing permissions and
+  # limitations under the License.
+  ##########################################################################
+
+
+---
+- hosts: all
+  vars: 
+    get_id1: "processors[?component.name=='ExecuteProcess'].id" 
+    get_id2: "processors[?component.name=='PutFile'].id"  
+    dest_cred_file_path: "~/.globus/"
+    proccess_arguments: "-sync -r {{intermediate_folder}} gsiftp://{{gridftp_user}}@{{gridftp_host}}:{{gridftp_port}}/{{gridftp_directory}}"
+
+  tasks:
+    - name: create directory for cred file
+      file:
+        path: "{{dest_cred_file_path}}"
+        state: directory
+
+    - name: Upload the credentials file to the current directory. 
+      copy:
+        src: "{{gridftp_cert_path}}"
+        dest: "{{dest_cred_file_path}}"
+      when: gridftp_cert_path != "none" or gridftp_cert_path != "None"
+
+
+    - name: Get list of available NiFi processors within the process group
+      uri:
+        url: "http://localhost:8080/nifi-api/process-groups/{{pipeline_id}}/processors"
+        method: Get
+      register: nifi_resources
+      when: cred_file_path != "none" or cred_file_path != "None"
+
+
+
+    - name: Configure the ExecuteProcess process group
+      vars:
+        first_prcsr_id: "{{ nifi_resources.json  | to_json | from_json | json_query(get_id1) }}"
+      uri:
+        url: "http://localhost:8080/nifi-api/processors/{{first_prcsr_id}}"
+        method: PUT
+        body:
+          "revision": { "version": 0}
+          "component": 
+            "id": "{{first_prcsr_id}}"
+            "config": 
+              "properties": { 
+                "Command Arguments": "{{proccess_arguments}}",
+            }                       
+        status_code: 200
+        body_format: json
+
+    - name: Configure the ListFile processor within the process group
+      vars:       
+        second_prcsr_id: "{{ nifi_resources.json  | to_json | from_json | json_query(get_id2) }}"
+      uri:
+        url: "http://localhost:8080/nifi-api/processors/{{second_prcsr_id}}"
+        method: PUT
+        body:
+          "revision": { "version": 0}
+          "component": 
+            "id": "{{second_prcsr_id}}"
+            "config": 
+              "properties": {  
+                 "properties": { "Directory": "{{intermediate_folder}}"}
+              }                       
+        status_code: 200
+        body_format: json
+
+
+    
+
+
+
+

--- a/nodetypes/radon.nodes.datapipeline.destination/PublishGridFtp/files/configure/configure.yml.mimetype
+++ b/nodetypes/radon.nodes.datapipeline.destination/PublishGridFtp/files/configure/configure.yml.mimetype
@@ -1,0 +1,1 @@
+text/plain

--- a/nodetypes/radon.nodes.datapipeline.destination/PublishGridFtp/files/create/create.yml
+++ b/nodetypes/radon.nodes.datapipeline.destination/PublishGridFtp/files/create/create.yml
@@ -1,0 +1,83 @@
+  ##########################################################################
+  # Copyright (c) 2019 Contributors to the RADON project
+  #
+  # Licensed under the Apache License, Version 2.0 (the "License");
+  # you may not use this file except in compliance with the License.
+  # You may obtain a copy of the License at
+  #
+  #     http://www.apache.org/licenses/LICENSE-2.0
+  #
+  # Unless required by applicable law or agreed to in writing, software
+  # distributed under the License is distributed on an "AS IS" BASIS,
+  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  # See the License for the specific language governing permissions and
+  # limitations under the License.
+  ##########################################################################
+ 
+
+---
+- hosts: all
+  vars: 
+    query: "resources[?name=='{{template_name}}' && starts_with(identifier, '/templates/')].identifier"
+    
+  tasks:
+
+    
+    - name: Copy template file to remote system (shell command requires file to be in remote system)
+      copy:
+        src: "{{ template_file }}"
+        dest: template.xml
+
+    - name: Wait for port 8080 to become open on the host ( dont start checking for 4 seconds )
+      wait_for:
+        port: 8080
+        delay: 4
+
+    - name: upload template file to NiFi template repository
+      shell: 'curl  -X "POST" "http://localhost:8080/nifi-api/process-groups/root/templates/upload" \
+                 -H "Content-Type: multipart/form-data; charset=utf-8; boundary=__X_PAW_BOUNDARY__" \
+                 -k \
+                 --form template=@template.xml'
+      register: response 
+
+    - name: Get list of available NiFi resources for fetching the id of the template by its name
+      uri:
+        url: http://localhost:8080/nifi-api/resources
+        method: Get
+      register: nifi_resources 
+
+    - name: Initiate the template 
+      vars:
+        template_id: "{{ nifi_resources.json  | to_json | from_json | json_query(query) | first}}"
+      uri:
+        url: http://localhost:8080/nifi-api/process-groups/root/template-instance
+        method: POST
+        body:
+          "originX": 2.0
+          "originY": 3.0 
+          "templateId": "{{template_id.split('/')[2]}}"
+        status_code: 201
+        body_format: json
+      register: pipeline_info
+
+    # - name: Ansible create file if it doesn't exist example
+    #   copy:
+    #     dest: "/tmp/pipeline_info{{template_name}}.txt"
+    #     content: "pipeline_info are : {{ pipeline_info }}"
+
+    ## set PROCESS-GROUP for S3BUCKET
+    - name: Set pipeline id property value (process-groups)
+      set_stats:
+        data:
+          id: "{{ pipeline_info.json.flow.processGroups[0].id }}"        
+#          pipeline_type: "processGroups"
+      when: pipeline_info.json.flow.processGroups|length > 0
+    # - name: Ansible create file if it doesn't exist example
+    #   copy:
+    #     dest: "/tmp/id_processGroups.txt"
+    #     content: "{{pipeline_info.json.flow.processGroups[0].id}}"
+    #   when: pipeline_info.json.flow.processGroups|length > 0
+
+
+
+    

--- a/nodetypes/radon.nodes.datapipeline.destination/PublishGridFtp/files/create/create.yml
+++ b/nodetypes/radon.nodes.datapipeline.destination/PublishGridFtp/files/create/create.yml
@@ -21,7 +21,40 @@
     query: "resources[?name=='{{template_name}}' && starts_with(identifier, '/templates/')].identifier"
     
   tasks:
+    - name: Install gridftp client and proxy on Ubuntu
+      become: yes
+      apt:
+        name:
+          - globus-proxy-utils
+          - globus-gass-copy-progs
+          - tree
+        state: present
+        update_cache: yes
+      when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
+      
 
+    - name: Import a key from a Glubus.org
+      become: yes
+      ansible.builtin.rpm_key:
+        state: present
+        key: https://downloads.globus.org/toolkit/gt6/stable/repo/rpm/RPM-GPG-KEY-Globus
+      when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux'
+      
+    - name: Install gridftp client and proxy on CENTOS
+      become: yes
+      yum:
+        name:
+          - https://downloads.globus.org/toolkit/globus-connect-server/globus-connect-server-repo-latest.noarch.rpm
+        state: present
+      when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux'
+ 
+    - name: Install gridftp client and proxy on CENTOS
+      become: yes
+      yum:
+        name:
+          - globus-gass-copy-progs
+        state: present
+      when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux' 
     
     - name: Copy template file to remote system (shell command requires file to be in remote system)
       copy:

--- a/nodetypes/radon.nodes.datapipeline.destination/PublishGridFtp/files/create/create.yml.mimetype
+++ b/nodetypes/radon.nodes.datapipeline.destination/PublishGridFtp/files/create/create.yml.mimetype
@@ -1,0 +1,1 @@
+text/plain

--- a/nodetypes/radon.nodes.datapipeline.destination/PublishGridFtp/files/templateFile_localConn/GridFTPpublish.xml
+++ b/nodetypes/radon.nodes.datapipeline.destination/PublishGridFtp/files/templateFile_localConn/GridFTPpublish.xml
@@ -1,0 +1,275 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<template encoding-version="1.3">
+    <description>data pipeline node type implementation to send data/files to GridFTP server</description>
+    <groupId>1daafc72-0176-1000-59bc-bb2d5bac73a0</groupId>
+    <name>GridFTPpublish</name>
+    <snippet>
+        <processGroups>
+            <id>1e986bd1-d0e2-36a6-0000-000000000000</id>
+            <parentGroupId>264b917f-ed22-31dc-0000-000000000000</parentGroupId>
+            <position>
+                <x>0.0</x>
+                <y>0.0</y>
+            </position>
+            <comments></comments>
+            <contents>
+                <connections>
+                    <id>0943bae9-c637-32cb-0000-000000000000</id>
+                    <parentGroupId>1e986bd1-d0e2-36a6-0000-000000000000</parentGroupId>
+                    <backPressureDataSizeThreshold>1 GB</backPressureDataSizeThreshold>
+                    <backPressureObjectThreshold>10000</backPressureObjectThreshold>
+                    <destination>
+                        <groupId>1e986bd1-d0e2-36a6-0000-000000000000</groupId>
+                        <id>6c4a2eda-8df4-302c-0000-000000000000</id>
+                        <type>PROCESSOR</type>
+                    </destination>
+                    <flowFileExpiration>0 sec</flowFileExpiration>
+                    <labelIndex>1</labelIndex>
+                    <loadBalanceCompression>DO_NOT_COMPRESS</loadBalanceCompression>
+                    <loadBalancePartitionAttribute></loadBalancePartitionAttribute>
+                    <loadBalanceStatus>LOAD_BALANCE_NOT_CONFIGURED</loadBalanceStatus>
+                    <loadBalanceStrategy>DO_NOT_LOAD_BALANCE</loadBalanceStrategy>
+                    <name></name>
+                    <source>
+                        <groupId>1e986bd1-d0e2-36a6-0000-000000000000</groupId>
+                        <id>39a3563c-1feb-3534-0000-000000000000</id>
+                        <type>INPUT_PORT</type>
+                    </source>
+                    <zIndex>0</zIndex>
+                </connections>
+                <inputPorts>
+                    <id>39a3563c-1feb-3534-0000-000000000000</id>
+                    <parentGroupId>1e986bd1-d0e2-36a6-0000-000000000000</parentGroupId>
+                    <position>
+                        <x>360.0</x>
+                        <y>448.0</y>
+                    </position>
+                    <comments></comments>
+                    <concurrentlySchedulableTaskCount>1</concurrentlySchedulableTaskCount>
+                    <name>GridFTPinput</name>
+                    <state>STOPPED</state>
+                    <type>INPUT_PORT</type>
+                    <validationErrors>'Port 'GridFTPinput'' is invalid because Port has no incoming connections</validationErrors>
+                </inputPorts>
+                <processors>
+                    <id>6c4a2eda-8df4-302c-0000-000000000000</id>
+                    <parentGroupId>1e986bd1-d0e2-36a6-0000-000000000000</parentGroupId>
+                    <position>
+                        <x>896.0</x>
+                        <y>400.0</y>
+                    </position>
+                    <bundle>
+                        <artifact>nifi-standard-nar</artifact>
+                        <group>org.apache.nifi</group>
+                        <version>1.12.1</version>
+                    </bundle>
+                    <config>
+                        <bulletinLevel>WARN</bulletinLevel>
+                        <comments></comments>
+                        <concurrentlySchedulableTaskCount>1</concurrentlySchedulableTaskCount>
+                        <descriptors>
+                            <entry>
+<key>Directory</key>
+<value>
+    <name>Directory</name>
+</value>
+                            </entry>
+                            <entry>
+<key>Conflict Resolution Strategy</key>
+<value>
+    <name>Conflict Resolution Strategy</name>
+</value>
+                            </entry>
+                            <entry>
+<key>Create Missing Directories</key>
+<value>
+    <name>Create Missing Directories</name>
+</value>
+                            </entry>
+                            <entry>
+<key>Maximum File Count</key>
+<value>
+    <name>Maximum File Count</name>
+</value>
+                            </entry>
+                            <entry>
+<key>Last Modified Time</key>
+<value>
+    <name>Last Modified Time</name>
+</value>
+                            </entry>
+                            <entry>
+<key>Permissions</key>
+<value>
+    <name>Permissions</name>
+</value>
+                            </entry>
+                            <entry>
+<key>Owner</key>
+<value>
+    <name>Owner</name>
+</value>
+                            </entry>
+                            <entry>
+<key>Group</key>
+<value>
+    <name>Group</name>
+</value>
+                            </entry>
+                        </descriptors>
+                        <executionNode>ALL</executionNode>
+                        <lossTolerant>false</lossTolerant>
+                        <penaltyDuration>30 sec</penaltyDuration>
+                        <properties>
+                            <entry>
+<key>Directory</key>
+<value>/tmp/nifi_gridftp_publish</value>
+                            </entry>
+                            <entry>
+<key>Conflict Resolution Strategy</key>
+<value>fail</value>
+                            </entry>
+                            <entry>
+<key>Create Missing Directories</key>
+<value>true</value>
+                            </entry>
+                            <entry>
+<key>Maximum File Count</key>
+                            </entry>
+                            <entry>
+<key>Last Modified Time</key>
+                            </entry>
+                            <entry>
+<key>Permissions</key>
+                            </entry>
+                            <entry>
+<key>Owner</key>
+                            </entry>
+                            <entry>
+<key>Group</key>
+                            </entry>
+                        </properties>
+                        <runDurationMillis>0</runDurationMillis>
+                        <schedulingPeriod>0 sec</schedulingPeriod>
+                        <schedulingStrategy>TIMER_DRIVEN</schedulingStrategy>
+                        <yieldDuration>1 sec</yieldDuration>
+                    </config>
+                    <executionNodeRestricted>false</executionNodeRestricted>
+                    <name>PutFile</name>
+                    <relationships>
+                        <autoTerminate>true</autoTerminate>
+                        <name>failure</name>
+                    </relationships>
+                    <relationships>
+                        <autoTerminate>true</autoTerminate>
+                        <name>success</name>
+                    </relationships>
+                    <state>RUNNING</state>
+                    <style/>
+                    <type>org.apache.nifi.processors.standard.PutFile</type>
+                </processors>
+                <processors>
+                    <id>788d5990-d337-345f-0000-000000000000</id>
+                    <parentGroupId>1e986bd1-d0e2-36a6-0000-000000000000</parentGroupId>
+                    <position>
+                        <x>896.0</x>
+                        <y>656.0</y>
+                    </position>
+                    <bundle>
+                        <artifact>nifi-standard-nar</artifact>
+                        <group>org.apache.nifi</group>
+                        <version>1.12.1</version>
+                    </bundle>
+                    <config>
+                        <bulletinLevel>WARN</bulletinLevel>
+                        <comments></comments>
+                        <concurrentlySchedulableTaskCount>1</concurrentlySchedulableTaskCount>
+                        <descriptors>
+                            <entry>
+<key>Command</key>
+<value>
+    <name>Command</name>
+</value>
+                            </entry>
+                            <entry>
+<key>Command Arguments</key>
+<value>
+    <name>Command Arguments</name>
+</value>
+                            </entry>
+                            <entry>
+<key>Batch Duration</key>
+<value>
+    <name>Batch Duration</name>
+</value>
+                            </entry>
+                            <entry>
+<key>Redirect Error Stream</key>
+<value>
+    <name>Redirect Error Stream</name>
+</value>
+                            </entry>
+                            <entry>
+<key>Working Directory</key>
+<value>
+    <name>Working Directory</name>
+</value>
+                            </entry>
+                            <entry>
+<key>Argument Delimiter</key>
+<value>
+    <name>Argument Delimiter</name>
+</value>
+                            </entry>
+                        </descriptors>
+                        <executionNode>ALL</executionNode>
+                        <lossTolerant>false</lossTolerant>
+                        <penaltyDuration>30 sec</penaltyDuration>
+                        <properties>
+                            <entry>
+<key>Command</key>
+<value>globus-url-copy</value>
+                            </entry>
+                            <entry>
+<key>Command Arguments</key>
+<value>-sync -r /tmp/nifi_gridftp_publish/ gsiftp://pelle@sodalite-fe.hlrs.de:2811/~/gridftp_input/</value>
+                            </entry>
+                            <entry>
+<key>Batch Duration</key>
+                            </entry>
+                            <entry>
+<key>Redirect Error Stream</key>
+<value>false</value>
+                            </entry>
+                            <entry>
+<key>Working Directory</key>
+                            </entry>
+                            <entry>
+<key>Argument Delimiter</key>
+<value> </value>
+                            </entry>
+                        </properties>
+                        <runDurationMillis>0</runDurationMillis>
+                        <schedulingPeriod>1 sec</schedulingPeriod>
+                        <schedulingStrategy>TIMER_DRIVEN</schedulingStrategy>
+                        <yieldDuration>1 sec</yieldDuration>
+                    </config>
+                    <executionNodeRestricted>false</executionNodeRestricted>
+                    <name>ExecuteProcess</name>
+                    <relationships>
+                        <autoTerminate>true</autoTerminate>
+                        <name>success</name>
+                    </relationships>
+                    <state>RUNNING</state>
+                    <style/>
+                    <type>org.apache.nifi.processors.standard.ExecuteProcess</type>
+                </processors>
+            </contents>
+            <flowfileConcurrency>UNBOUNDED</flowfileConcurrency>
+            <flowfileOutboundPolicy>STREAM_WHEN_AVAILABLE</flowfileOutboundPolicy>
+            <name>GridFTPpublish</name>
+            <variables/>
+        </processGroups>
+    </snippet>
+    <timestamp>02/18/2021 10:52:02 UTC</timestamp>
+</template>

--- a/nodetypes/radon.nodes.datapipeline.destination/PublishGridFtp/files/templateFile_localConn/GridFTPpublish.xml.mimetype
+++ b/nodetypes/radon.nodes.datapipeline.destination/PublishGridFtp/files/templateFile_localConn/GridFTPpublish.xml.mimetype
@@ -1,0 +1,1 @@
+application/xml

--- a/nodetypes/radon.nodes.datapipeline.destination/PubsS3Bucket/files/templateFile_LocalConn/S3Bucket_dest_PG_LocalConn.xml
+++ b/nodetypes/radon.nodes.datapipeline.destination/PubsS3Bucket/files/templateFile_LocalConn/S3Bucket_dest_PG_LocalConn.xml
@@ -406,7 +406,7 @@ The data are from LOCAL pipeline</description>
                             </entry>
                         </properties>
                         <runDurationMillis>0</runDurationMillis>
-                        <schedulingPeriod>60 sec</schedulingPeriod>
+                        <schedulingPeriod>0 sec</schedulingPeriod>
                         <schedulingStrategy>TIMER_DRIVEN</schedulingStrategy>
                         <yieldDuration>1 sec</yieldDuration>
                     </config>

--- a/nodetypes/radon.nodes.datapipeline.source/ConsumeGridFtp/NodeType.tosca
+++ b/nodetypes/radon.nodes.datapipeline.source/ConsumeGridFtp/NodeType.tosca
@@ -2,6 +2,7 @@ tosca_definitions_version: tosca_simple_yaml_1_3
 
 node_types:
   radon.nodes.datapipeline.source.ConsumeGridFtp:
+    derived_from: radon.nodes.datapipeline.source.ConsumeRemote
     metadata:
       targetNamespace: "radon.nodes.datapipeline.source"
       abstract: "false"
@@ -66,6 +67,10 @@ node_types:
                 type: string
                 required: true
                 default: { get_property: [ SELF, intermediate_folder ] }
+              pipeline_id:
+                type: string
+                required: true
+                default: { get_attribute: [ SELF, id ] }
               gridftp_user:
                 type: string
                 required: true
@@ -96,5 +101,5 @@ node_types:
         file: create.yml
       configure:
         type: radon.artifacts.Ansible
-        description: configure life cycle operation implementation script
+        description: implementation of configure operation
         file: configure.yml

--- a/nodetypes/radon.nodes.datapipeline.source/ConsumeGridFtp/NodeType.tosca
+++ b/nodetypes/radon.nodes.datapipeline.source/ConsumeGridFtp/NodeType.tosca
@@ -96,7 +96,7 @@ node_types:
         description: XML template file
         file: GridFTPsubscribe.xml
       create:
-        type: tosca.artifacts.File
+        type: radon.artifacts.Ansible
         description: create operation implementation in Ansible
         file: create.yml
       configure:

--- a/nodetypes/radon.nodes.datapipeline.source/ConsumeGridFtp/NodeType.tosca
+++ b/nodetypes/radon.nodes.datapipeline.source/ConsumeGridFtp/NodeType.tosca
@@ -1,0 +1,100 @@
+tosca_definitions_version: tosca_simple_yaml_1_3
+
+node_types:
+  radon.nodes.datapipeline.source.ConsumeGridFtp:
+    metadata:
+      targetNamespace: "radon.nodes.datapipeline.source"
+      abstract: "false"
+      final: "false"
+    attributes:
+      template_name:
+        description: name of the template
+        type: string
+        default: "GridFTPsubscribe"
+    properties:
+      gridftp_port:
+        type: string
+        description: port of the gridftp server
+        default: 2811
+      intermediate_folder:
+        type: string
+        description: Where the data pipeline server keeps intermediate data. MUST be unique folder.
+        default: "/tmp/nifi_gridftp_subscribe/"
+      gridftp_user:
+        type: string
+        description: user of the gridftp server
+        default: "pelle"
+      gridftp_host:
+        type: string
+        description: hostname of the gridftp server
+        default: "gridftpserver.com"
+      gridftp_cert_path:
+        type: string
+        description: where the orchestrator copies certificates from, to enable connection into GridFTP server using the specified user. Folder has to be accessible by the orchestrator.
+        default: "/tmp/gridftp_certs/"
+      gridftp_directory:
+        type: string
+        description: directory from where to take data inside the GridFTP server
+        default: "~/gridftp_output/"
+    interfaces:
+      Standard:
+        type: tosca.interfaces.node.lifecycle.Standard
+        operations:
+          create:
+            description: The standard create operation
+            inputs:
+              template_name:
+                type: string
+                required: true
+                default: { get_attribute: [ SELF, template_name ] }
+              template_file:
+                type: string
+                required: true
+                default: "GridFTPsubscribe.xml"
+            implementation:
+              primary: create
+              dependencies: [ templateFile_localConn ]
+              timeout: 0
+          configure:
+            description: The standard configure operation
+            inputs:
+              gridftp_port:
+                type: string
+                required: true
+                default: { get_property: [ SELF, gridftp_port ] }
+              intermediate_folder:
+                type: string
+                required: true
+                default: { get_property: [ SELF, intermediate_folder ] }
+              gridftp_user:
+                type: string
+                required: true
+                default: { get_property: [ SELF, gridftp_user ] }
+              gridftp_host:
+                type: string
+                required: true
+                default: { get_property: [ SELF, gridftp_host ] }
+              gridftp_cert_path:
+                type: string
+                required: true
+                default: { get_property: [ SELF, gridftp_cert_path ] }
+              gridftp_directory:
+                type: string
+                required: true
+                default: { get_property: [ SELF, gridftp_directory ] }
+            implementation:
+              primary: configure
+              timeout: 0
+    artifacts:
+      templateFile_localConn:
+        type: tosca.artifacts.File
+        description: XML template file
+        file: GridFTPsubscribe.xml
+      create:
+        type: tosca.artifacts.File
+        description: create operation implementation in Ansible
+        file: create.yml
+      configure:
+        type: radon.artifacts.Ansible
+        description: configure life cycle operation implementation script
+        file: configure.yml

--- a/nodetypes/radon.nodes.datapipeline.source/ConsumeGridFtp/NodeType.tosca.old
+++ b/nodetypes/radon.nodes.datapipeline.source/ConsumeGridFtp/NodeType.tosca.old
@@ -1,0 +1,100 @@
+tosca_definitions_version: tosca_simple_yaml_1_3
+
+node_types:
+  radon.nodes.datapipeline.source.ConsumeGridFtp:
+    metadata:
+      targetNamespace: "radon.nodes.datapipeline.source"
+      abstract: "false"
+      final: "false"
+    attributes:
+      template_name:
+        description: name of the template
+        type: string
+        default: "GridFTPsubscribe"
+    properties:
+      gridftp_port:
+        type: string
+        description: port of the gridftp server
+        default: 2811
+      intermediate_folder:
+        type: string
+        description: Where the data pipeline server keeps intermediate data. MUST be unique folder.
+        default: "/tmp/nifi_gridftp_subscribe/"
+      gridftp_user:
+        type: string
+        description: user of the gridftp server
+        default: "pelle"
+      gridftp_host:
+        type: string
+        description: hostname of the gridftp server
+        default: "gridftpserver.com"
+      gridftp_cert_path:
+        type: string
+        description: where the orchestrator copies certificates from, to enable connection into GridFTP server using the specified user. Folder has to be accessible by the orchestrator.
+        default: "/tmp/gridftp_certs/"
+      gridftp_directory:
+        type: string
+        description: directory from where to take data inside the GridFTP server
+        default: "~/gridftp_output/"
+    interfaces:
+      Standard:
+        type: tosca.interfaces.node.lifecycle.Standard
+        operations:
+          create:
+            description: The standard create operation
+            inputs:
+              template_name:
+                type: string
+                required: true
+                default: { get_attribute: [ SELF, template_name ] }
+              template_file:
+                type: string
+                required: true
+                default: "GridFTPsubscribe.xml"
+            implementation:
+              primary: create
+              dependencies: [ templateFile_localConn ]
+              timeout: 0
+          configure:
+            description: The standard configure operation
+            inputs:
+              gridftp_port:
+                type: string
+                required: true
+                default: { get_property: [ SELF, gridftp_port ] }
+              intermediate_folder:
+                type: string
+                required: true
+                default: { get_property: [ SELF, intermediate_folder ] }
+              gridftp_user:
+                type: string
+                required: true
+                default: { get_property: [ SELF, gridftp_user ] }	
+              gridftp_host:
+                type: string
+                required: true
+                default: { get_property: [ SELF, gridftp_host ] }
+              gridftp_cert_path:
+                type: string
+                required: true
+                default: { get_property: [ SELF, gridftp_cert_path ] }
+              gridftp_directory:
+                type: string
+                required: true
+                default: { get_property: [ SELF, gridftp_directory ] }
+            implementation:
+              primary: configure
+              timeout: 0
+    artifacts:
+      templateFile_localConn:
+        type: tosca.artifacts.File
+        description: XML template file
+        file: GridFTPsubscribe.xml
+      create:
+        type: tosca.artifacts.File
+        description: create operation implementation in Ansible
+        file: create.yml
+      configure:
+        type: radon.artifacts.Ansible
+        description: configure life cycle operation implementation script
+        file: configure.yml

--- a/nodetypes/radon.nodes.datapipeline.source/ConsumeGridFtp/files/configure/configure.yml
+++ b/nodetypes/radon.nodes.datapipeline.source/ConsumeGridFtp/files/configure/configure.yml
@@ -20,19 +20,21 @@
   vars: 
     get_id1: "processors[?component.name=='ExecuteProcess'].id" 
     get_id2: "processors[?component.name=='ListFile'].id"  
-    dest_cred_file_path: "~/.globus/"
+    dest_cred_file_path: "/root/"
     proccess_arguments: "-sync -r gsiftp://{{gridftp_user}}@{{gridftp_host}}:{{gridftp_port}}/{{gridftp_directory}} {{intermediate_folder}}"
   
   tasks:
-    - name: create directory for cred file
+    - name: create directory for intermediate files
       file:
-        path: "{{dest_cred_file_path}}"
+        path: "{{intermediate_folder}}"
         state: directory
 
-    - name: Upload the credentials file to the current directory. 
+    - name: Upload the certificate files  
       copy:
         src: "{{gridftp_cert_path}}"
         dest: "{{dest_cred_file_path}}"
+        mode: 0600
+      become: yes
       when: gridftp_cert_path != "none" or gridftp_cert_path != "None"
 
 

--- a/nodetypes/radon.nodes.datapipeline.source/ConsumeGridFtp/files/configure/configure.yml
+++ b/nodetypes/radon.nodes.datapipeline.source/ConsumeGridFtp/files/configure/configure.yml
@@ -1,0 +1,87 @@
+  ##########################################################################
+  # Copyright (c) 2019 Contributors to the RADON project
+  #
+  # Licensed under the Apache License, Version 2.0 (the "License");
+  # you may not use this file except in compliance with the License.
+  # You may obtain a copy of the License at
+  #
+  #     http://www.apache.org/licenses/LICENSE-2.0
+  #
+  # Unless required by applicable law or agreed to in writing, software
+  # distributed under the License is distributed on an "AS IS" BASIS,
+  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  # See the License for the specific language governing permissions and
+  # limitations under the License.
+  ##########################################################################
+
+
+---
+- hosts: all
+  vars: 
+    get_id1: "processors[?component.name=='ExecuteProcess'].id" 
+    get_id2: "processors[?component.name=='ListFile'].id"  
+    dest_cred_file_path: "~/.globus/"
+    proccess_arguments: "-sync -r gsiftp://{{gridftp_user}}@{{gridftp_host}}:{{gridftp_port}}/{{gridftp_directory}} {{intermediate_folder}}"
+  
+  tasks:
+    - name: create directory for cred file
+      file:
+        path: "{{dest_cred_file_path}}"
+        state: directory
+
+    - name: Upload the credentials file to the current directory. 
+      copy:
+        src: "{{gridftp_cert_path}}"
+        dest: "{{dest_cred_file_path}}"
+      when: gridftp_cert_path != "none" or gridftp_cert_path != "None"
+
+
+    - name: Get list of available NiFi processors within the process group
+      uri:
+        url: "http://localhost:8080/nifi-api/process-groups/{{pipeline_id}}/processors"
+        method: Get
+      register: nifi_resources
+      when: cred_file_path != "none" or cred_file_path != "None"
+
+
+
+    - name: Configure the ExecuteProcess process group
+      vars:
+        first_prcsr_id: "{{ nifi_resources.json  | to_json | from_json | json_query(get_id1) }}"
+      uri:
+        url: "http://localhost:8080/nifi-api/processors/{{first_prcsr_id}}"
+        method: PUT
+        body:
+          "revision": { "version": 0}
+          "component": 
+            "id": "{{first_prcsr_id}}"
+            "config": 
+              "properties": { 
+                "Command Arguments": "{{proccess_arguments}}",
+            }                       
+        status_code: 200
+        body_format: json
+
+    - name: Configure the ListFile processor within the process group
+      vars:       
+        second_prcsr_id: "{{ nifi_resources.json  | to_json | from_json | json_query(get_id2) }}"
+      uri:
+        url: "http://localhost:8080/nifi-api/processors/{{second_prcsr_id}}"
+        method: PUT
+        body:
+          "revision": { "version": 0}
+          "component": 
+            "id": "{{second_prcsr_id}}"
+            "config": 
+              "properties": {  
+                 "properties": { "Input Directory": "{{intermediate_folder}}"}
+              }                       
+        status_code: 200
+        body_format: json
+
+
+    
+
+
+
+

--- a/nodetypes/radon.nodes.datapipeline.source/ConsumeGridFtp/files/configure/configure.yml
+++ b/nodetypes/radon.nodes.datapipeline.source/ConsumeGridFtp/files/configure/configure.yml
@@ -41,13 +41,12 @@
         url: "http://localhost:8080/nifi-api/process-groups/{{pipeline_id}}/processors"
         method: Get
       register: nifi_resources
-      when: cred_file_path != "none" or cred_file_path != "None"
 
 
 
     - name: Configure the ExecuteProcess process group
       vars:
-        first_prcsr_id: "{{ nifi_resources.json  | to_json | from_json | json_query(get_id1) }}"
+        first_prcsr_id: "{{ nifi_resources.json  | to_json | from_json | json_query(get_id1)| first }}"
       uri:
         url: "http://localhost:8080/nifi-api/processors/{{first_prcsr_id}}"
         method: PUT
@@ -64,7 +63,7 @@
 
     - name: Configure the ListFile processor within the process group
       vars:       
-        second_prcsr_id: "{{ nifi_resources.json  | to_json | from_json | json_query(get_id2) }}"
+        second_prcsr_id: "{{ nifi_resources.json  | to_json | from_json | json_query(get_id2)| first }}"
       uri:
         url: "http://localhost:8080/nifi-api/processors/{{second_prcsr_id}}"
         method: PUT
@@ -74,7 +73,7 @@
             "id": "{{second_prcsr_id}}"
             "config": 
               "properties": {  
-                 "properties": { "Input Directory": "{{intermediate_folder}}"}
+                 "Input Directory": "{{intermediate_folder}}",
               }                       
         status_code: 200
         body_format: json

--- a/nodetypes/radon.nodes.datapipeline.source/ConsumeGridFtp/files/configure/configure.yml.mimetype
+++ b/nodetypes/radon.nodes.datapipeline.source/ConsumeGridFtp/files/configure/configure.yml.mimetype
@@ -1,0 +1,1 @@
+text/plain

--- a/nodetypes/radon.nodes.datapipeline.source/ConsumeGridFtp/files/create/create.yml
+++ b/nodetypes/radon.nodes.datapipeline.source/ConsumeGridFtp/files/create/create.yml
@@ -1,0 +1,83 @@
+  ##########################################################################
+  # Copyright (c) 2019 Contributors to the RADON project
+  #
+  # Licensed under the Apache License, Version 2.0 (the "License");
+  # you may not use this file except in compliance with the License.
+  # You may obtain a copy of the License at
+  #
+  #     http://www.apache.org/licenses/LICENSE-2.0
+  #
+  # Unless required by applicable law or agreed to in writing, software
+  # distributed under the License is distributed on an "AS IS" BASIS,
+  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  # See the License for the specific language governing permissions and
+  # limitations under the License.
+  ##########################################################################
+ 
+
+---
+- hosts: all
+  vars: 
+    query: "resources[?name=='{{template_name}}' && starts_with(identifier, '/templates/')].identifier"
+    
+  tasks:
+
+    
+    - name: Copy template file to remote system (shell command requires file to be in remote system)
+      copy:
+        src: "{{ template_file }}"
+        dest: template.xml
+
+    - name: Wait for port 8080 to become open on the host ( dont start checking for 4 seconds )
+      wait_for:
+        port: 8080
+        delay: 4
+
+    - name: upload template file to NiFi template repository
+      shell: 'curl  -X "POST" "http://localhost:8080/nifi-api/process-groups/root/templates/upload" \
+                 -H "Content-Type: multipart/form-data; charset=utf-8; boundary=__X_PAW_BOUNDARY__" \
+                 -k \
+                 --form template=@template.xml'
+      register: response 
+
+    - name: Get list of available NiFi resources for fetching the id of the template by its name
+      uri:
+        url: http://localhost:8080/nifi-api/resources
+        method: Get
+      register: nifi_resources 
+
+    - name: Initiate the template 
+      vars:
+        template_id: "{{ nifi_resources.json  | to_json | from_json | json_query(query) | first}}"
+      uri:
+        url: http://localhost:8080/nifi-api/process-groups/root/template-instance
+        method: POST
+        body:
+          "originX": 2.0
+          "originY": 3.0 
+          "templateId": "{{template_id.split('/')[2]}}"
+        status_code: 201
+        body_format: json
+      register: pipeline_info
+
+    # - name: Ansible create file if it doesn't exist example
+    #   copy:
+    #     dest: "/tmp/pipeline_info{{template_name}}.txt"
+    #     content: "pipeline_info are : {{ pipeline_info }}"
+
+    ## set PROCESS-GROUP for S3BUCKET
+    - name: Set pipeline id property value (process-groups)
+      set_stats:
+        data:
+          id: "{{ pipeline_info.json.flow.processGroups[0].id }}"        
+#          pipeline_type: "processGroups"
+      when: pipeline_info.json.flow.processGroups|length > 0
+    # - name: Ansible create file if it doesn't exist example
+    #   copy:
+    #     dest: "/tmp/id_processGroups.txt"
+    #     content: "{{pipeline_info.json.flow.processGroups[0].id}}"
+    #   when: pipeline_info.json.flow.processGroups|length > 0
+
+
+
+    

--- a/nodetypes/radon.nodes.datapipeline.source/ConsumeGridFtp/files/create/create.yml
+++ b/nodetypes/radon.nodes.datapipeline.source/ConsumeGridFtp/files/create/create.yml
@@ -21,7 +21,40 @@
     query: "resources[?name=='{{template_name}}' && starts_with(identifier, '/templates/')].identifier"
     
   tasks:
+    - name: Install gridftp client and proxy on Ubuntu
+      become: yes
+      apt:
+        name:
+          - globus-proxy-utils
+          - globus-gass-copy-progs
+          - tree
+        state: present
+        update_cache: yes
+      when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
+      
 
+    - name: Import a key from a Glubus.org
+      become: yes
+      ansible.builtin.rpm_key:
+        state: present
+        key: https://downloads.globus.org/toolkit/gt6/stable/repo/rpm/RPM-GPG-KEY-Globus
+      when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux'
+      
+    - name: Install gridftp client and proxy on CENTOS
+      become: yes
+      yum:
+        name:
+          - https://downloads.globus.org/toolkit/globus-connect-server/globus-connect-server-repo-latest.noarch.rpm
+        state: present
+      when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux'
+ 
+    - name: Install gridftp client and proxy on CENTOS
+      become: yes
+      yum:
+        name:
+          - globus-gass-copy-progs
+        state: present
+      when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux' 
     
     - name: Copy template file to remote system (shell command requires file to be in remote system)
       copy:

--- a/nodetypes/radon.nodes.datapipeline.source/ConsumeGridFtp/files/create/create.yml.mimetype
+++ b/nodetypes/radon.nodes.datapipeline.source/ConsumeGridFtp/files/create/create.yml.mimetype
@@ -1,0 +1,1 @@
+text/plain

--- a/nodetypes/radon.nodes.datapipeline.source/ConsumeGridFtp/files/templateFile_localConn/GridFTPsubscribe.xml
+++ b/nodetypes/radon.nodes.datapipeline.source/ConsumeGridFtp/files/templateFile_localConn/GridFTPsubscribe.xml
@@ -1,0 +1,548 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<template encoding-version="1.3">
+    <description>Data pipeline node type implementation for consuming data/files from GridFTP</description>
+    <groupId>1daafc72-0176-1000-59bc-bb2d5bac73a0</groupId>
+    <name>GridFTPsubscribe</name>
+    <snippet>
+        <processGroups>
+            <id>71b9edb7-313a-35be-0000-000000000000</id>
+            <parentGroupId>264b917f-ed22-31dc-0000-000000000000</parentGroupId>
+            <position>
+                <x>0.0</x>
+                <y>0.0</y>
+            </position>
+            <comments></comments>
+            <contents>
+                <connections>
+                    <id>0860c3a0-f7b9-373f-0000-000000000000</id>
+                    <parentGroupId>71b9edb7-313a-35be-0000-000000000000</parentGroupId>
+                    <backPressureDataSizeThreshold>1 GB</backPressureDataSizeThreshold>
+                    <backPressureObjectThreshold>10000</backPressureObjectThreshold>
+                    <destination>
+                        <groupId>71b9edb7-313a-35be-0000-000000000000</groupId>
+                        <id>029e6774-fb5c-3511-0000-000000000000</id>
+                        <type>PROCESSOR</type>
+                    </destination>
+                    <flowFileExpiration>0 sec</flowFileExpiration>
+                    <labelIndex>1</labelIndex>
+                    <loadBalanceCompression>DO_NOT_COMPRESS</loadBalanceCompression>
+                    <loadBalancePartitionAttribute></loadBalancePartitionAttribute>
+                    <loadBalanceStatus>LOAD_BALANCE_NOT_CONFIGURED</loadBalanceStatus>
+                    <loadBalanceStrategy>DO_NOT_LOAD_BALANCE</loadBalanceStrategy>
+                    <name></name>
+                    <selectedRelationships>success</selectedRelationships>
+                    <source>
+                        <groupId>71b9edb7-313a-35be-0000-000000000000</groupId>
+                        <id>61c18c63-9760-34a4-0000-000000000000</id>
+                        <type>PROCESSOR</type>
+                    </source>
+                    <zIndex>0</zIndex>
+                </connections>
+                <connections>
+                    <id>47343bc4-596b-383f-0000-000000000000</id>
+                    <parentGroupId>71b9edb7-313a-35be-0000-000000000000</parentGroupId>
+                    <backPressureDataSizeThreshold>1 GB</backPressureDataSizeThreshold>
+                    <backPressureObjectThreshold>10000</backPressureObjectThreshold>
+                    <destination>
+                        <groupId>71b9edb7-313a-35be-0000-000000000000</groupId>
+                        <id>d7345f7f-495c-3250-0000-000000000000</id>
+                        <type>OUTPUT_PORT</type>
+                    </destination>
+                    <flowFileExpiration>0 sec</flowFileExpiration>
+                    <labelIndex>1</labelIndex>
+                    <loadBalanceCompression>DO_NOT_COMPRESS</loadBalanceCompression>
+                    <loadBalancePartitionAttribute></loadBalancePartitionAttribute>
+                    <loadBalanceStatus>LOAD_BALANCE_NOT_CONFIGURED</loadBalanceStatus>
+                    <loadBalanceStrategy>DO_NOT_LOAD_BALANCE</loadBalanceStrategy>
+                    <name></name>
+                    <selectedRelationships>success</selectedRelationships>
+                    <source>
+                        <groupId>71b9edb7-313a-35be-0000-000000000000</groupId>
+                        <id>029e6774-fb5c-3511-0000-000000000000</id>
+                        <type>PROCESSOR</type>
+                    </source>
+                    <zIndex>0</zIndex>
+                </connections>
+                <outputPorts>
+                    <id>d7345f7f-495c-3250-0000-000000000000</id>
+                    <parentGroupId>71b9edb7-313a-35be-0000-000000000000</parentGroupId>
+                    <position>
+                        <x>1072.0</x>
+                        <y>128.0</y>
+                    </position>
+                    <comments></comments>
+                    <concurrentlySchedulableTaskCount>1</concurrentlySchedulableTaskCount>
+                    <name>GridFTPoutput</name>
+                    <state>STOPPED</state>
+                    <type>OUTPUT_PORT</type>
+                    <validationErrors>'Port 'GridFTPoutput'' is invalid because Port has no outgoing connections</validationErrors>
+                </outputPorts>
+                <processors>
+                    <id>029e6774-fb5c-3511-0000-000000000000</id>
+                    <parentGroupId>71b9edb7-313a-35be-0000-000000000000</parentGroupId>
+                    <position>
+                        <x>672.0</x>
+                        <y>504.0</y>
+                    </position>
+                    <bundle>
+                        <artifact>nifi-standard-nar</artifact>
+                        <group>org.apache.nifi</group>
+                        <version>1.12.1</version>
+                    </bundle>
+                    <config>
+                        <bulletinLevel>WARN</bulletinLevel>
+                        <comments></comments>
+                        <concurrentlySchedulableTaskCount>1</concurrentlySchedulableTaskCount>
+                        <descriptors>
+                            <entry>
+<key>File to Fetch</key>
+<value>
+    <name>File to Fetch</name>
+</value>
+                            </entry>
+                            <entry>
+<key>Completion Strategy</key>
+<value>
+    <name>Completion Strategy</name>
+</value>
+                            </entry>
+                            <entry>
+<key>Move Destination Directory</key>
+<value>
+    <name>Move Destination Directory</name>
+</value>
+                            </entry>
+                            <entry>
+<key>Move Conflict Strategy</key>
+<value>
+    <name>Move Conflict Strategy</name>
+</value>
+                            </entry>
+                            <entry>
+<key>Log level when file not found</key>
+<value>
+    <name>Log level when file not found</name>
+</value>
+                            </entry>
+                            <entry>
+<key>Log level when permission denied</key>
+<value>
+    <name>Log level when permission denied</name>
+</value>
+                            </entry>
+                        </descriptors>
+                        <executionNode>ALL</executionNode>
+                        <lossTolerant>false</lossTolerant>
+                        <penaltyDuration>30 sec</penaltyDuration>
+                        <properties>
+                            <entry>
+<key>File to Fetch</key>
+<value>${absolute.path}/${filename}</value>
+                            </entry>
+                            <entry>
+<key>Completion Strategy</key>
+<value>None</value>
+                            </entry>
+                            <entry>
+<key>Move Destination Directory</key>
+                            </entry>
+                            <entry>
+<key>Move Conflict Strategy</key>
+<value>Rename</value>
+                            </entry>
+                            <entry>
+<key>Log level when file not found</key>
+<value>ERROR</value>
+                            </entry>
+                            <entry>
+<key>Log level when permission denied</key>
+<value>ERROR</value>
+                            </entry>
+                        </properties>
+                        <runDurationMillis>0</runDurationMillis>
+                        <schedulingPeriod>0 sec</schedulingPeriod>
+                        <schedulingStrategy>TIMER_DRIVEN</schedulingStrategy>
+                        <yieldDuration>1 sec</yieldDuration>
+                    </config>
+                    <executionNodeRestricted>false</executionNodeRestricted>
+                    <name>FetchFile</name>
+                    <relationships>
+                        <autoTerminate>true</autoTerminate>
+                        <name>failure</name>
+                    </relationships>
+                    <relationships>
+                        <autoTerminate>true</autoTerminate>
+                        <name>not.found</name>
+                    </relationships>
+                    <relationships>
+                        <autoTerminate>true</autoTerminate>
+                        <name>permission.denied</name>
+                    </relationships>
+                    <relationships>
+                        <autoTerminate>false</autoTerminate>
+                        <name>success</name>
+                    </relationships>
+                    <state>RUNNING</state>
+                    <style/>
+                    <type>org.apache.nifi.processors.standard.FetchFile</type>
+                </processors>
+                <processors>
+                    <id>1d7d612b-efe6-3b22-0000-000000000000</id>
+                    <parentGroupId>71b9edb7-313a-35be-0000-000000000000</parentGroupId>
+                    <position>
+                        <x>280.0</x>
+                        <y>32.0</y>
+                    </position>
+                    <bundle>
+                        <artifact>nifi-standard-nar</artifact>
+                        <group>org.apache.nifi</group>
+                        <version>1.12.1</version>
+                    </bundle>
+                    <config>
+                        <bulletinLevel>WARN</bulletinLevel>
+                        <comments></comments>
+                        <concurrentlySchedulableTaskCount>1</concurrentlySchedulableTaskCount>
+                        <descriptors>
+                            <entry>
+<key>Command</key>
+<value>
+    <name>Command</name>
+</value>
+                            </entry>
+                            <entry>
+<key>Command Arguments</key>
+<value>
+    <name>Command Arguments</name>
+</value>
+                            </entry>
+                            <entry>
+<key>Batch Duration</key>
+<value>
+    <name>Batch Duration</name>
+</value>
+                            </entry>
+                            <entry>
+<key>Redirect Error Stream</key>
+<value>
+    <name>Redirect Error Stream</name>
+</value>
+                            </entry>
+                            <entry>
+<key>Working Directory</key>
+<value>
+    <name>Working Directory</name>
+</value>
+                            </entry>
+                            <entry>
+<key>Argument Delimiter</key>
+<value>
+    <name>Argument Delimiter</name>
+</value>
+                            </entry>
+                        </descriptors>
+                        <executionNode>ALL</executionNode>
+                        <lossTolerant>false</lossTolerant>
+                        <penaltyDuration>30 sec</penaltyDuration>
+                        <properties>
+                            <entry>
+<key>Command</key>
+<value>globus-url-copy</value>
+                            </entry>
+                            <entry>
+<key>Command Arguments</key>
+<value>-sync -r gsiftp://pelle@sodalite-fe.hlrs.de:2811/~/gridftp_output/ /tmp/nifi_gridftp_subscribe/</value>
+                            </entry>
+                            <entry>
+<key>Batch Duration</key>
+                            </entry>
+                            <entry>
+<key>Redirect Error Stream</key>
+<value>false</value>
+                            </entry>
+                            <entry>
+<key>Working Directory</key>
+                            </entry>
+                            <entry>
+<key>Argument Delimiter</key>
+<value> </value>
+                            </entry>
+                        </properties>
+                        <runDurationMillis>0</runDurationMillis>
+                        <schedulingPeriod>3 sec</schedulingPeriod>
+                        <schedulingStrategy>TIMER_DRIVEN</schedulingStrategy>
+                        <yieldDuration>1 sec</yieldDuration>
+                    </config>
+                    <executionNodeRestricted>false</executionNodeRestricted>
+                    <name>ExecuteProcess</name>
+                    <relationships>
+                        <autoTerminate>true</autoTerminate>
+                        <name>success</name>
+                    </relationships>
+                    <state>RUNNING</state>
+                    <style/>
+                    <type>org.apache.nifi.processors.standard.ExecuteProcess</type>
+                </processors>
+                <processors>
+                    <id>61c18c63-9760-34a4-0000-000000000000</id>
+                    <parentGroupId>71b9edb7-313a-35be-0000-000000000000</parentGroupId>
+                    <position>
+                        <x>280.0</x>
+                        <y>256.0</y>
+                    </position>
+                    <bundle>
+                        <artifact>nifi-standard-nar</artifact>
+                        <group>org.apache.nifi</group>
+                        <version>1.12.1</version>
+                    </bundle>
+                    <config>
+                        <bulletinLevel>WARN</bulletinLevel>
+                        <comments></comments>
+                        <concurrentlySchedulableTaskCount>1</concurrentlySchedulableTaskCount>
+                        <descriptors>
+                            <entry>
+<key>Input Directory</key>
+<value>
+    <name>Input Directory</name>
+</value>
+                            </entry>
+                            <entry>
+<key>listing-strategy</key>
+<value>
+    <name>listing-strategy</name>
+</value>
+                            </entry>
+                            <entry>
+<key>Recurse Subdirectories</key>
+<value>
+    <name>Recurse Subdirectories</name>
+</value>
+                            </entry>
+                            <entry>
+<key>record-writer</key>
+<value>
+    <identifiesControllerService>org.apache.nifi.serialization.RecordSetWriterFactory</identifiesControllerService>
+    <name>record-writer</name>
+</value>
+                            </entry>
+                            <entry>
+<key>Input Directory Location</key>
+<value>
+    <name>Input Directory Location</name>
+</value>
+                            </entry>
+                            <entry>
+<key>File Filter</key>
+<value>
+    <name>File Filter</name>
+</value>
+                            </entry>
+                            <entry>
+<key>Path Filter</key>
+<value>
+    <name>Path Filter</name>
+</value>
+                            </entry>
+                            <entry>
+<key>Include File Attributes</key>
+<value>
+    <name>Include File Attributes</name>
+</value>
+                            </entry>
+                            <entry>
+<key>Minimum File Age</key>
+<value>
+    <name>Minimum File Age</name>
+</value>
+                            </entry>
+                            <entry>
+<key>Maximum File Age</key>
+<value>
+    <name>Maximum File Age</name>
+</value>
+                            </entry>
+                            <entry>
+<key>Minimum File Size</key>
+<value>
+    <name>Minimum File Size</name>
+</value>
+                            </entry>
+                            <entry>
+<key>Maximum File Size</key>
+<value>
+    <name>Maximum File Size</name>
+</value>
+                            </entry>
+                            <entry>
+<key>Ignore Hidden Files</key>
+<value>
+    <name>Ignore Hidden Files</name>
+</value>
+                            </entry>
+                            <entry>
+<key>target-system-timestamp-precision</key>
+<value>
+    <name>target-system-timestamp-precision</name>
+</value>
+                            </entry>
+                            <entry>
+<key>et-state-cache</key>
+<value>
+    <identifiesControllerService>org.apache.nifi.distributed.cache.client.DistributedMapCacheClient</identifiesControllerService>
+    <name>et-state-cache</name>
+</value>
+                            </entry>
+                            <entry>
+<key>et-time-window</key>
+<value>
+    <name>et-time-window</name>
+</value>
+                            </entry>
+                            <entry>
+<key>et-initial-listing-target</key>
+<value>
+    <name>et-initial-listing-target</name>
+</value>
+                            </entry>
+                            <entry>
+<key>et-node-identifier</key>
+<value>
+    <name>et-node-identifier</name>
+</value>
+                            </entry>
+                            <entry>
+<key>track-performance</key>
+<value>
+    <name>track-performance</name>
+</value>
+                            </entry>
+                            <entry>
+<key>max-performance-metrics</key>
+<value>
+    <name>max-performance-metrics</name>
+</value>
+                            </entry>
+                            <entry>
+<key>max-operation-time</key>
+<value>
+    <name>max-operation-time</name>
+</value>
+                            </entry>
+                            <entry>
+<key>max-listing-time</key>
+<value>
+    <name>max-listing-time</name>
+</value>
+                            </entry>
+                        </descriptors>
+                        <executionNode>ALL</executionNode>
+                        <lossTolerant>false</lossTolerant>
+                        <penaltyDuration>30 sec</penaltyDuration>
+                        <properties>
+                            <entry>
+<key>Input Directory</key>
+<value>/tmp/nifi_gridftp_subscribe/</value>
+                            </entry>
+                            <entry>
+<key>listing-strategy</key>
+<value>timestamps</value>
+                            </entry>
+                            <entry>
+<key>Recurse Subdirectories</key>
+<value>true</value>
+                            </entry>
+                            <entry>
+<key>record-writer</key>
+                            </entry>
+                            <entry>
+<key>Input Directory Location</key>
+<value>Local</value>
+                            </entry>
+                            <entry>
+<key>File Filter</key>
+<value>[^\.].*</value>
+                            </entry>
+                            <entry>
+<key>Path Filter</key>
+                            </entry>
+                            <entry>
+<key>Include File Attributes</key>
+<value>true</value>
+                            </entry>
+                            <entry>
+<key>Minimum File Age</key>
+<value>0 sec</value>
+                            </entry>
+                            <entry>
+<key>Maximum File Age</key>
+                            </entry>
+                            <entry>
+<key>Minimum File Size</key>
+<value>0 B</value>
+                            </entry>
+                            <entry>
+<key>Maximum File Size</key>
+                            </entry>
+                            <entry>
+<key>Ignore Hidden Files</key>
+<value>true</value>
+                            </entry>
+                            <entry>
+<key>target-system-timestamp-precision</key>
+<value>auto-detect</value>
+                            </entry>
+                            <entry>
+<key>et-state-cache</key>
+                            </entry>
+                            <entry>
+<key>et-time-window</key>
+<value>3 hours</value>
+                            </entry>
+                            <entry>
+<key>et-initial-listing-target</key>
+<value>all</value>
+                            </entry>
+                            <entry>
+<key>et-node-identifier</key>
+<value>${hostname()}</value>
+                            </entry>
+                            <entry>
+<key>track-performance</key>
+<value>false</value>
+                            </entry>
+                            <entry>
+<key>max-performance-metrics</key>
+<value>100000</value>
+                            </entry>
+                            <entry>
+<key>max-operation-time</key>
+<value>10 secs</value>
+                            </entry>
+                            <entry>
+<key>max-listing-time</key>
+<value>3 mins</value>
+                            </entry>
+                        </properties>
+                        <runDurationMillis>0</runDurationMillis>
+                        <schedulingPeriod>0 sec</schedulingPeriod>
+                        <schedulingStrategy>TIMER_DRIVEN</schedulingStrategy>
+                        <yieldDuration>1 sec</yieldDuration>
+                    </config>
+                    <executionNodeRestricted>false</executionNodeRestricted>
+                    <name>ListFile</name>
+                    <relationships>
+                        <autoTerminate>false</autoTerminate>
+                        <name>success</name>
+                    </relationships>
+                    <state>RUNNING</state>
+                    <style/>
+                    <type>org.apache.nifi.processors.standard.ListFile</type>
+                </processors>
+            </contents>
+            <flowfileConcurrency>UNBOUNDED</flowfileConcurrency>
+            <flowfileOutboundPolicy>STREAM_WHEN_AVAILABLE</flowfileOutboundPolicy>
+            <name>GridFTPsubscribe</name>
+            <variables/>
+        </processGroups>
+    </snippet>
+    <timestamp>02/18/2021 10:51:11 UTC</timestamp>
+</template>

--- a/nodetypes/radon.nodes.datapipeline.source/ConsumeGridFtp/files/templateFile_localConn/GridFTPsubscribe.xml.mimetype
+++ b/nodetypes/radon.nodes.datapipeline.source/ConsumeGridFtp/files/templateFile_localConn/GridFTPsubscribe.xml.mimetype
@@ -1,0 +1,1 @@
+application/xml

--- a/servicetemplates/radon.blueprints.examples/S3toGridFTPpipeline/ServiceTemplate.tosca
+++ b/servicetemplates/radon.blueprints.examples/S3toGridFTPpipeline/ServiceTemplate.tosca
@@ -1,0 +1,85 @@
+tosca_definitions_version: tosca_simple_yaml_1_3
+
+metadata:
+  targetNamespace: "radon.blueprints.examples"
+topology_template:
+  node_templates:
+    PublishGridFtp_0:
+      type: radon.nodes.datapipeline.destination.PublishGridFtp
+      metadata:
+        x: "1009"
+        y: "183"
+        displayName: "PublishGridFtp"
+      properties:
+        gridftp_port: 2811
+        intermediate_folder: "/tmp/nifi_gridftp_subscribe/"
+        schedulingStrategy: "EVENT_DRIVEN"
+        schedulingPeriodCRON: "* * * * * ?"
+        name: "sendTogridFTP"
+        gridftp_user: "pelle"
+        gridftp_host: "sodalite-fe.hlrs.de"
+        gridftp_cert_path: "/tmp/gridftp_certs/"
+        gridftp_directory: "~/gridftp_input/"
+      requirements:
+        - host:
+            node: Nifi_0
+            relationship: con_HostedOn_2
+            capability: host
+    ConsS3Bucket_0:
+      type: radon.nodes.datapipeline.source.ConsS3Bucket
+      metadata:
+        x: "327"
+        y: "178"
+        displayName: "ConsS3Bucket"
+      properties:
+        BucketName: "radon-jakovits"
+        cred_file_path: "/home/jakovits/aws/credentials"
+        schedulingStrategy: "EVENT_DRIVEN"
+        schedulingPeriodCRON: "* * * * * ?"
+        name: "listenFromS3"
+        Region: "eu-central-1"
+      requirements:
+        - connectToPipeline:
+            node: PublishGridFtp_0
+            relationship: con_ConnectNifiLocal_0
+            capability: ConnectToPipeline
+        - host:
+            node: Nifi_0
+            relationship: con_HostedOn_1
+            capability: host
+    OpenStack_0:
+      type: radon.nodes.VM.OpenStack
+      metadata:
+        x: "673"
+        y: "699"
+        displayName: "OpenStack"
+      properties:
+        flavor: "6b254b9e-db1c-40de-994c-07d69dd732a6"
+        key_name: "jakovits_ldpc"
+        image: "13a94b11-98ee-43a4-ad29-00ae97e8f790"
+        ssh_username: "centos"
+        name: "nifihost3"
+        network: "provider_64_net"
+    Nifi_0:
+      type: radon.nodes.nifi.Nifi
+      metadata:
+        x: "666"
+        y: "378"
+        displayName: "Nifi"
+      properties:
+        port: 8080
+        component_version: "1.13.0"
+      requirements:
+        - host:
+            node: OpenStack_0
+            relationship: con_HostedOn_0
+            capability: host
+  relationship_templates:
+    con_HostedOn_2:
+      type: tosca.relationships.HostedOn
+    con_HostedOn_0:
+      type: tosca.relationships.HostedOn
+    con_HostedOn_1:
+      type: tosca.relationships.HostedOn
+    con_ConnectNifiLocal_0:
+      type: radon.relationships.datapipeline.ConnectNifiLocal

--- a/servicetemplates/radon.blueprints.examples/S3toGridFTPpipeline/ServiceTemplate.tosca
+++ b/servicetemplates/radon.blueprints.examples/S3toGridFTPpipeline/ServiceTemplate.tosca
@@ -12,7 +12,7 @@ topology_template:
         displayName: "PublishGridFtp"
       properties:
         gridftp_port: 2811
-        intermediate_folder: "/tmp/nifi_gridftp_subscribe/"
+        intermediate_folder: "/tmp/nifi_gridftp_publish/"
         schedulingStrategy: "EVENT_DRIVEN"
         schedulingPeriodCRON: "* * * * * ?"
         name: "sendTogridFTP"

--- a/servicetemplates/radon.blueprints.examples/S3toGridFTPpipeline/ServiceTemplate.tosca
+++ b/servicetemplates/radon.blueprints.examples/S3toGridFTPpipeline/ServiceTemplate.tosca
@@ -18,7 +18,7 @@ topology_template:
         name: "sendTogridFTP"
         gridftp_user: "pelle"
         gridftp_host: "sodalite-fe.hlrs.de"
-        gridftp_cert_path: "/tmp/gridftp_certs/"
+        gridftp_cert_path: "/home/jakovits/.globus"
         gridftp_directory: "~/gridftp_input/"
       requirements:
         - host:

--- a/servicetemplates/radon.blueprints.examples/gridFTPtoS3pipeline/ServiceTemplate.tosca
+++ b/servicetemplates/radon.blueprints.examples/gridFTPtoS3pipeline/ServiceTemplate.tosca
@@ -18,7 +18,7 @@ topology_template:
         name: "receieveFromGFTP"
         gridftp_user: "pelle"
         gridftp_host: "gridftpserver.com"
-        gridftp_cert_path: "/tmp/gridftp_certs/"
+        gridftp_cert_path: "/home/jakovits/.globus"
         gridftp_directory: "~/gridftp_output/"
       requirements:
         - connectToPipeline:

--- a/servicetemplates/radon.blueprints.examples/gridFTPtoS3pipeline/ServiceTemplate.tosca
+++ b/servicetemplates/radon.blueprints.examples/gridFTPtoS3pipeline/ServiceTemplate.tosca
@@ -17,7 +17,7 @@ topology_template:
         schedulingPeriodCRON: "* * * * * ?"
         name: "receieveFromGFTP"
         gridftp_user: "pelle"
-        gridftp_host: "gridftpserver.com"
+        gridftp_host: "sodalite-fe.hlrs.de"
         gridftp_cert_path: "/home/jakovits/.globus"
         gridftp_directory: "~/gridftp_output/"
       requirements:

--- a/servicetemplates/radon.blueprints.examples/gridFTPtoS3pipeline/ServiceTemplate.tosca
+++ b/servicetemplates/radon.blueprints.examples/gridFTPtoS3pipeline/ServiceTemplate.tosca
@@ -1,0 +1,85 @@
+tosca_definitions_version: tosca_simple_yaml_1_3
+
+metadata:
+  targetNamespace: "radon.blueprints.examples"
+topology_template:
+  node_templates:
+    ConsumeGridFtp_0:
+      type: radon.nodes.datapipeline.source.ConsumeGridFtp
+      metadata:
+        x: "307"
+        y: "71"
+        displayName: "ConsumeGridFtp"
+      properties:
+        gridftp_port: 2811
+        intermediate_folder: "/tmp/nifi_gridftp_subscribe/"
+        schedulingStrategy: "EVENT_DRIVEN"
+        schedulingPeriodCRON: "* * * * * ?"
+        name: "receieveFromGFTP"
+        gridftp_user: "pelle"
+        gridftp_host: "gridftpserver.com"
+        gridftp_cert_path: "/tmp/gridftp_certs/"
+        gridftp_directory: "~/gridftp_output/"
+      requirements:
+        - connectToPipeline:
+            node: PubsS3Bucket_0
+            relationship: con_ConnectNifiLocal_0
+            capability: ConnectToPipeline
+        - host:
+            node: Nifi_0
+            relationship: con_HostedOn_2
+            capability: host
+    PubsS3Bucket_0:
+      type: radon.nodes.datapipeline.destination.PubsS3Bucket
+      metadata:
+        x: "1042"
+        y: "63"
+        displayName: "PubsS3Bucket"
+      properties:
+        BucketName: "radon-jakovits-output"
+        cred_file_path: "/home/jakovits/aws/credentials"
+        schedulingStrategy: "EVENT_DRIVEN"
+        schedulingPeriodCRON: "* * * * * ?"
+        name: "sendToS3"
+        Region: "eu-central-1"
+      requirements:
+        - host:
+            node: Nifi_0
+            relationship: con_HostedOn_1
+            capability: host
+    OpenStack_0:
+      type: radon.nodes.VM.OpenStack
+      metadata:
+        x: "669"
+        y: "660"
+        displayName: "OpenStack"
+      properties:
+        flavor: "6b254b9e-db1c-40de-994c-07d69dd732a6"
+        key_name: "jakovits_ldpc"
+        image: "13a94b11-98ee-43a4-ad29-00ae97e8f790"
+        ssh_username: "centos"
+        name: "nifihost3"
+        network: "provider_64_net"
+    Nifi_0:
+      type: radon.nodes.nifi.Nifi
+      metadata:
+        x: "650"
+        y: "397"
+        displayName: "Nifi"
+      properties:
+        port: 8080
+        component_version: "1.13.0"
+      requirements:
+        - host:
+            node: OpenStack_0
+            relationship: con_HostedOn_0
+            capability: host
+  relationship_templates:
+    con_HostedOn_2:
+      type: tosca.relationships.HostedOn
+    con_HostedOn_0:
+      type: tosca.relationships.HostedOn
+    con_HostedOn_1:
+      type: tosca.relationships.HostedOn
+    con_ConnectNifiLocal_0:
+      type: radon.relationships.datapipeline.ConnectNifiLocal


### PR DESCRIPTION
This pull requests contains two GridFTP related TOSCA node types and two example service templates which are needed for the RADON-SODALITE collaboration demonstration application. 

Node types:

1. radon.nodes.datapipeline.destination.PublishGridFtp 
2. radon.nodes.datapipeline.source.ConsumeGridFtp

Service templates:
1. radon.blueprints.examples/S3toGridFTPpipeline
2. radon.blueprints.examples/gridFTPtoS3pipeline

